### PR TITLE
UI Rework

### DIFF
--- a/ClientApp/ClientApp/Components/Layout/NavMenu.razor
+++ b/ClientApp/ClientApp/Components/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">ClientApp</a>
+        <a class="navbar-brand" href=""> Gifting & Co</a>
     </div>
 </div>
 
@@ -10,17 +10,17 @@
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
+                <span class="bi bi-gift-nav-menu" aria-hidden="true"></span> GiftHome
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="content">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Content
+                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Empty
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Empty
             </NavLink>
         </div>
     </nav>

--- a/ClientApp/ClientApp/Components/Layout/NavMenu.razor.css
+++ b/ClientApp/ClientApp/Components/Layout/NavMenu.razor.css
@@ -22,6 +22,7 @@
 
 .navbar-brand {
     font-size: 1.1rem;
+    width: 50%;
 }
 
 .bi {
@@ -34,8 +35,8 @@
     background-size: cover;
 }
 
-.bi-house-door-fill-nav-menu {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-house-door-fill' viewBox='0 0 16 16'%3E%3Cpath d='M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5Z'/%3E%3C/svg%3E");
+.bi-gift-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E %3Cpath d='M3 2.5C3 1.11929 4.11929 0 5.5 0C6.88071 0 8 1.11929 8 2.5C8 1.11929 9.11929 0 10.5 0C11.8807 0 13 1.11929 13 2.5L13 2.50557C13 2.57543 13.0001 2.77567 12.9622 3H15C15.5523 3 16 3.44772 16 4V6C16 6.55228 15.5523 7 15 7V14.5C15 15.3284 14.3284 16 13.5 16H2.5C1.67157 16 1 15.3284 1 14.5L1 7C0.447716 7 0 6.55229 0 6V4C0 3.44772 0.447715 3 1 3H3.03783C2.99987 2.77567 2.99996 2.57543 3 2.50557C3 2.50361 3 2.50175 3 2.5ZM4.06799 3H7V2.5C7 1.67157 6.32843 1 5.5 1C4.67157 1 4 1.67157 4 2.5C4 2.58475 4.00195 2.77351 4.04488 2.93094C4.05252 2.95895 4.06044 2.98186 4.06799 3ZM9 3H11.932C11.9396 2.98186 11.9475 2.95895 11.9551 2.93094C11.9981 2.77351 12 2.58475 12 2.5C12 1.67157 11.3284 1 10.5 1C9.67157 1 9 1.67157 9 2.5V3ZM1 4V6H7V4H1ZM9 4V6H15V4H9ZM14 7H9V15H13.5C13.7761 15 14 14.7761 14 14.5V7ZM7 15V7H2V14.5C2 14.7761 2.22386 15 2.5 15H7Z'/%3E %3C/svg%3E");
 }
 
 .bi-plus-square-fill-nav-menu {
@@ -49,6 +50,7 @@
 .nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;
+    border-radius: 20px;
 }
 
     .nav-item:first-of-type {
@@ -66,6 +68,7 @@
         display: flex;
         align-items: center;
         line-height: 3rem;
+        font-style: italic;
     }
 
         .nav-item ::deep a.active {

--- a/ClientApp/ClientApp/Components/Pages/Home.razor
+++ b/ClientApp/ClientApp/Components/Pages/Home.razor
@@ -3,7 +3,7 @@
 ﻿@using System.ComponentModel.DataAnnotations;
 @using ClientApp.Models;
 
-
+<div class="GiftHouseIncoporated"> 
 <div class="giftHouseCreation">
     <div class="createButton1">
         <button id="clickHouseButton"> Click to Create a GiftHouse! </button>
@@ -51,7 +51,7 @@
         </div> <!-- end joinHouseForm -->
     </div> <!-- end createButton2 -->
 </div> <!-- end giftHouseJoin -->
-
+</div> <!-- end GiftHouseIncoporated -->
 @code {
     public GiftHouse? GiftHouseData { get; set; } 
     public EditContext? EditContext { get; set; }

--- a/ClientApp/ClientApp/Components/Pages/Home.razor.css
+++ b/ClientApp/ClientApp/Components/Pages/Home.razor.css
@@ -1,6 +1,19 @@
-﻿.giftHouseCreation, .giftHouseJoin {
-    width: 100%;
+﻿* {
+    margin: 0 auto;
 }
+
+.GiftHouseIncoporated {
+    width: 960px;
+}
+
+.giftHouseCreation, .giftHouseJoin {
+    margin: 1%;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: center;
+}
+
 #clickHouseButton, #joinHouseButton {
     background-color: pink;
     color: black;
@@ -8,47 +21,52 @@
     font-size: 16px;
     border: none;
     cursor: pointer;
+    border-radius: 12px;
+    margin-bottom: 8px;
 }
+    /* #joinHouseButton {
+    margin-left: 60px;
+} */
+
     /*button id*/
     #clickHouseButton:hover, #joinHouseButton:hover {
         background-color: black;
         color: pink;
     }
-.giftHouseCreation, .giftHouseJoin {
-    position: relative;
-    width: 45.4%;
-}
 
 .createButton1, .createButton2 {
-    transition: all 90s ease-in-out;
+    transition: all 90s ease-in;
     opacity: 1;
     cursor: pointer;
 }
+
     .createButton1:hover, .createButton2:hover {
         opacity: .3;
     }
+
         .createButton1:hover .createHouseForm, .createButton2:hover .joinHouseForm {
             display: block;
         }
 /* dropdownHouseContent */
 .createHouseForm, .joinHouseForm {
     background-color: #f1f1f1;
-    height: auto;
+    border-radius: 12px;
     overflow: auto;
     padding: 25px 15px 15px 15px;
     text-align: center;
     display: none;
+    align-content: center;
 }
+
+    .joinHouseForm li:last-child {
+        margin-bottom: 20px;
+    }
 
 .houseButtons1, .houseButtons2 {
-    margin-bottom: 10px;
+    margin-bottom: 20px;
 }
 
-.houseButtons2 {
-    margin-bottom: 10px;
-}
-
-label {
+.label {
     width: 200px;
 }
 
@@ -56,11 +74,8 @@ label {
     border: 1px solid black;
     background: black;
     color: pink;
-}
-
-submitHouse {
-    margin-top: 10px;
-    text-align: center;
+    padding: 4%;
+    border-radius: 12px;
 }
 
 p.messageStore {
@@ -81,4 +96,25 @@ p.messageStore {
 .joinTable li {
     border-bottom: 1px solid pink;
     margin: 20px 0 10px 0;
+}
+
+/* responsive */
+
+@media only screen and (max-width: 700px) {
+    .GiftHouseIncoporated {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .giftHouseCreation, .giftHouseJoin {
+        flex: 50%;
+        max-width: 50%;
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .giftHouseCreation, .giftHouseJoin {
+        flex: 100%;
+        max-width: 100%;
+    }
 }

--- a/ClientApp/ClientApp/Components/Shared/_Header.razor
+++ b/ClientApp/ClientApp/Components/Shared/_Header.razor
@@ -1,5 +1,10 @@
-﻿<div class="header">
-    Gifting App Of *The* Gays
-    <br />
-    </div> <!-- end header-->
+﻿<div class="GiftingApp">
+    <nav id="mainNav">
+        <h1> Welcome To Gifting&Co </h1>
+        <ul>
+            <li><a href="GiftHouseCreation.html">GiftHouseCreation</a></li>
+        </ul>
+    </nav>
 
+
+</div> <!-- end GiftingApp -->

--- a/ClientApp/ClientApp/Components/Shared/_Header.razor.css
+++ b/ClientApp/ClientApp/Components/Shared/_Header.razor.css
@@ -1,0 +1,27 @@
+﻿* {
+    margin: 0 auto;
+}
+
+#mainNav h1, ul {
+    margin-top: 1%;
+    text-align: center;
+    border: 5px solid black;
+    border-radius: 20px;
+    width: 25%;
+    padding: 0;
+}
+
+#mainNav h1 {
+    color: black;
+    width: 44%;
+}
+
+#mainNav ul li {
+    list-style: none;
+}
+
+    #mainNav ul li a {
+        text-decoration: none;
+        font-style: italic;
+        color: black;
+    }

--- a/ClientApp/ClientApp/Models/GiftHouse.cs
+++ b/ClientApp/ClientApp/Models/GiftHouse.cs
@@ -5,11 +5,11 @@ namespace ClientApp.Models
     public class GiftHouse
     {
         [Required]
-        [StringLength(50, MinimumLength = 2, ErrorMessage = "The Gifthouse name must be between 2 and 50 characters.")]
+        [StringLength(30, MinimumLength = 2, ErrorMessage = "The Gifthouse name must be between 2 and 30 characters.")]
         public string? HouseName { get; set; }
 
         [Required]
-        [StringLength(50, MinimumLength = 2, ErrorMessage = "Your name/alias must be between 2 and 50 characters.")]
+        [StringLength(30, MinimumLength = 2, ErrorMessage = "Your name/alias must be between 2 and 30 characters.")]
         public string? CreatorName { get; set; }
     }
 }


### PR DESCRIPTION
NavMenu: edited the icons to a gift icon, renamed "Gifting&Co" as a fake name for length (for barebones template placement). Edited CSS for design/positioning.

Home: added an encompassing div "GiftHouseIncoporated". Edited CSS for design/positioning.

_Header: added a barebones navigation bar as well as an encompassing "GiftingApp" div. Edited CSS for design/positioning.

GiftHouse: edited string length for optimization.